### PR TITLE
fix: wrong tsconfig include paths

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,5 +27,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src/*.ts", "src/*.tsx", "src/@types/**.d.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["**.ts", "**.mts"]
+  "include": ["*.ts", "*.mts"]
 }


### PR DESCRIPTION
This pull request includes a modification to the `tsconfig.app.json` file to improve the TypeScript configuration by updating the `include` paths.

* [`tsconfig.app.json`](diffhunk://#diff-e71ce96b0b270cb476d6bd8c44bf0cdf6f0db749e316374a54f1b14aff8d63ddL30-R30): Changed the `include` paths to recursively include all TypeScript files within the `src` directory and its subdirectories.